### PR TITLE
Fix IllegalArgumentException from BirtDwellingBlock

### DIFF
--- a/src/main/java/com/ninni/species/block/BirtDwellingBlock.java
+++ b/src/main/java/com/ninni/species/block/BirtDwellingBlock.java
@@ -86,9 +86,11 @@ public class BirtDwellingBlock extends BaseEntityBlock {
     }
 
     private void angerNearbyBirts(Level world, BlockPos pos) {
+        List<Player> playerList = world.getEntitiesOfClass(Player.class, new AABB(pos).inflate(8.0, 6.0, 8.0));
+        if (playerList.isEmpty())
+            return;
         List<Birt> birtList = world.getEntitiesOfClass(Birt.class, new AABB(pos).inflate(8.0, 6.0, 8.0));
         if (!birtList.isEmpty()) {
-            List<Player> playerList = world.getEntitiesOfClass(Player.class, new AABB(pos).inflate(8.0, 6.0, 8.0));
             for (Birt birt : birtList) {
                 if (birt.getTarget() != null) continue;
                 birt.setTarget(playerList.get(world.random.nextInt(playerList.size())));


### PR DESCRIPTION
Fix IllegalArgumentException when no players are in the world.

<details>

<summary>Stacktrace</summary>

```
Description: Ticking entity

java.lang.IllegalArgumentException: Bound must be positive
	at net.minecraft.world.level.levelgen.BitRandomSource.nextInt(BitRandomSource.java:22) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at com.ninni.species.block.BirtDwellingBlock.angerNearbyBirts(BirtDwellingBlock.java:94) ~[species-1.20.1-2.2-forge.jar%23694!/:1.1.0] 
	at com.ninni.species.block.BirtDwellingBlock.playerDestroy(BirtDwellingBlock.java:83) ~[species-1.20.1-2.2-forge.jar%23694!/:1.1.0] 
	at net.minecraft.server.level.ServerPlayerGameMode.destroyBlock(ServerPlayerGameMode.java:256) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.level.ServerPlayerGameMode.tick(ServerPlayerGameMode.java:95) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.level.ServerPlayer.tick(ServerPlayer.java:428) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.level.ServerLevel.tickNonPassenger(ServerLevel.java:693) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.entity.TickOptimizer.handleGuardEntityTick(TickOptimizer.java:62) ~[NoSeeNoTick-2.0.0-1.20.1.jar%23631!/:2.0.0-build.9999] 
	at net.minecraft.entity.TickOptimizer.entityTicking(TickOptimizer.java:42) ~[NoSeeNoTick-2.0.0-1.20.1.jar%23631!/:2.0.0-build.9999] 
	at net.minecraft.world.level.Level.guardEntityTick(Level.java:2541) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.level.ServerLevel.lambda$tick$6(ServerLevel.java:343) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.world.level.entity.EntityTickList.forEach(EntityTickList.java:54) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:323) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:893) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:283) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:814) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:661) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:251) ~[server-1.20.1-20230612.114412-srg.jar%23757!/:?] 
	at java.lang.Thread.run(Thread.java:840) ~[?:?] 
```

</details>